### PR TITLE
Pass signal through transformer

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -12,12 +12,12 @@ const buildTransformer = (parseMode: string) => {
     console.warn(`Could not find parse_mode: ${parseMode}. If this is a valid parse_mode, you should ignore this message.`);
   }
 
-  const transformer: Transformer = (prev, method, payload) => {
+  const transformer: Transformer = (prev, method, payload, signal) => {
     if (!payload || 'parse_mode' in payload) {
-      return prev(method, payload);
+      return prev(method, payload, signal);
     }
 
-    return prev(method, { ...payload, ...{ parse_mode: normalisedParseMode } });
+    return prev(method, { ...payload, ...{ parse_mode: normalisedParseMode } }, signal);
   };
   return transformer;
 };


### PR DESCRIPTION
The transformer discards the signal. As a result, when this plugins is used, requests cannot be aborted anymore.

This PR fixes the issue by passing the signal on when calling `prev`.