### PR TITLE
doc: include JSDoc for deno docs

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,13 +1,24 @@
 import type { MessageEntity } from "./deps.deno.ts";
 
+/**
+ * Represents a string that can be formatted with Telegram entities.
+ */
 export interface Stringable {
   toString(): string;
 }
 
+/**
+ * Represents the formatted string after the parsing.
+ */
 class FormattedString implements Stringable {
   text: string;
   entities: MessageEntity[];
 
+  /**
+   * Creates a new FormattedString.
+   * @param text The text of the string.
+   * @param entities The entities of the message.
+   */
   constructor(text: string, entities: MessageEntity[]) {
     this.text = text;
     this.entities = entities;
@@ -18,6 +29,11 @@ class FormattedString implements Stringable {
   }
 }
 
+/**
+ * Unwraps a normal string into a FormattedString with no entities
+ * @param stringLike The string to unwrap
+ * @returns A new formatted string instance with no entities
+ */
 const unwrap = (stringLike: Stringable): FormattedString => {
   if (stringLike instanceof FormattedString) {
     return stringLike;
@@ -47,20 +63,66 @@ const buildFormatter = <T extends Array<any> = never>(
 };
 
 // Native entity functions
+/**
+ * Formats the string as bold.
+ * @param stringLike The string to format.
+ */
 const bold = buildFormatter("bold");
+/**
+ * Formats the string as inline code.
+ * @param stringLike The string to format.
+ */
 const code = buildFormatter("code");
+/**
+ * Formats the string as italic.
+ * @param stringLike The string to format.
+ */
 const italic = buildFormatter("italic");
+/**
+ * Formats the string as a link.
+ * @param stringLike The string to format.
+ * @param url The URL to link to.
+ */
 const link = buildFormatter<[string]>("text_link", "url");
+/**
+ * Formats the string as a code block
+ * @param stringLike The string to format.
+ * @param language The language of the code block.
+ */
 const pre = buildFormatter<[string]>("pre", "language");
+/**
+ * Formats the string as a spoiler.
+ * @param stringLike The string to format.
+ */
 const spoiler = buildFormatter("spoiler");
+/**
+ * Formats the string as a strikethrough.
+ * @param stringLike The string to format.
+ */
 const strikethrough = buildFormatter("strikethrough");
+/**
+ * Formats the string as a underline
+ * @param stringLike The string to format.
+ */
 const underline = buildFormatter("underline");
 
 // Utility functions
+
+/**
+ * Formats the string as an internal Telegram link to a user.
+ * @param stringLike The string to format.
+ * @param userId The user ID to link to.
+ */
 const mentionUser = (stringLike: Stringable, userId: number) => {
   return link(stringLike, `tg://user?id=${userId}`);
 };
 
+/**
+ * Formats the string as a Telegram link to a chat message.
+ * @param stringLike The string to format.
+ * @param chatId The chat ID to link to.
+ * @param messageId The message ID to link to.
+ */
 const linkMessage = (stringLike: Stringable, chatId: number, messageId: number) => {
   if (chatId > 0) {
     console.warn("linkMessage can only be used for supergroups and channel messages. Refusing to transform into link.");
@@ -74,6 +136,12 @@ const linkMessage = (stringLike: Stringable, chatId: number, messageId: number) 
 };
 
 // Root format function
+
+/**
+ * This is the root format function, it can be used to format a string with multiple entities and their given values.
+ * @param rawStringParts An array of string parts to be replaced with values
+ * @param stringLikes The array of string-like values to replace the string parts with
+ */
 const fmt = (
   rawStringParts: TemplateStringsArray | string[],
   ...stringLikes: Stringable[]

--- a/src/hydrate.ts
+++ b/src/hydrate.ts
@@ -10,6 +10,10 @@ type Tail<T extends Array<any>> = T extends [head: infer E1, ...tail: infer E2]
   ? E2
   : [];
 
+/**
+ * Represents a context that has been hydrated with a set of methods to reply
+ * @param C The context type
+ */
 type ParseModeFlavor<C extends Context> = C & {
   replyFmt: (
     stringLike: Stringable,
@@ -40,6 +44,11 @@ const buildReplyWithParseMode = <C extends Context>(
   };
 };
 
+/**
+ * Hydrates a context with a set of methods to reply with a given parse mode.
+ * @param ctx The context to hydrate
+ * @param next The next function to middleware
+ */
 const middleware = async <C extends Context>(
   ctx: ParseModeFlavor<C>,
   next: NextFunction,

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -6,6 +6,12 @@ const wellKnownParseModesMap = new Map([
   ["markdownv2", "MarkdownV2"],
 ]);
 
+/**
+ * Creates a new transformer for the givem parse mode.
+ * @param parseMode {string} The parse mode to use. If the parse mode is not in the well known parse modes map, it will be used as is.
+ * @see https://core.telegram.org/bots/api#formatting-options for well known parse modes.
+ * @returns {Transformer} The transformer.
+ */
 const buildTransformer = (parseMode: string) => {
   const normalisedParseMode =
     wellKnownParseModesMap.get(parseMode.toLowerCase()) ?? parseMode;


### PR DESCRIPTION
This fixes #10 

I just added the docs for the exported members, so the internal members are not documented (looked at the deno docs to check which ones of them are exposed)