### PR TITLE
refactor: add parse modes type hints, minor refactoring

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -2,9 +2,8 @@ import type { ParseMode, Transformer } from "./deps.deno.ts";
 
 /**
  * Creates a new transformer for the given parse mode.
- * @param parseMode {string} The parse mode to use.
- * @see https://core.telegram.org/bots/api#formatting-options
- *   for more information about formatting.
+ * @param parseMode {ParseMode} The parse mode to use.
+ * @see https://core.telegram.org/bots/api#formatting-options for more information about formatting.
  * @returns {Transformer} The transformer.
  */
 const buildTransformer = (parseMode: ParseMode): Transformer => (


### PR DESCRIPTION
Changes made:
- `wellKnownParseModesMap` map was replaced with `knownParseModes` object;
- `buildTransformer` (a.k.a. `parseMode`) arrow function was transformed to regular function and also was overloaded to show type hints of available parse modes;
- `src/transformer.ts` file formatted with Deno.