### PR TITLE
[Major] Make fmt use intuitive

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "deno.enable": true,
-    "deno.lint": true,
-    "deno.unstable": true
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "deno.enable": true,
+    "deno.lint": true,
+    "deno.unstable": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
   "deno.enable": true,
-  "deno.lint": true,
-  "deno.unstable": true
+  "deno.lint": true
 }

--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # Parse Mode plugin for grammY
 
 This plugin provides transformer that injects `entities` or `caption_entities`
-if `text` or `caption` are FormattedString. It also provides a middleware that
-installs this transformer on the `ctx.api` object.
+if `text` or `caption` are FormattedString.
 
 ## Usage (Using format)
 
 ```ts
-import { Bot, Context } from 'grammy';
-import { bold, fmt, hydrateReply, italic } from '@grammyjs/parse-mode';
-import type { ParseModeFlavor } from '@grammyjs/parse-mode';
+import { Api, Bot, Context } from "grammy";
+import { bold, fmt, hydrateFmt, underline } from "@grammyjs/parse-mode";
+import type { ParseModeApiFlavor, ParseModeFlavor } from "@grammyjs/parse-mode";
 
-const bot = new Bot<ParseModeFlavor<Context>>('');
+type MyApi = ParseModeApiFlavor<Api>;
+type MyContext = ParseModeFlavor<Context & { api: MyApi }>;
+const bot = new Bot<MyContext, MyApi>("");
 
 // Install automatic entities inject from FormattedString transformer
-bot.use(hydrateReply());
+bot.api.config.use(hydrateFmt());
 
-bot.command('demo', async ctx => {
-  const boldText = fmt`This is a ${bold('bolded')} string`;
+bot.command("demo", async (ctx) => {
+  const boldText = fmt`This is a ${bold("bolded")} string`;
   await ctx.reply(boldText);
 
-  const underlineText = fmt`This is an ${underline('underlined')}`;
-  await ctx.reply(underlineText);
+  const underlineText = fmt`This is an ${underline("underlined")}`;
+  await ctx.api.sendMessage(ctx.chat.id, underlineText);
 
   // fmt can also be use to concat FormattedStrings
-  cosnt combinedText = fmt`${boldText}\n${underlineText}`
-  await ctx.reply(combinedText);
+  const combinedText = fmt`${boldText}\n${underlineText}`;
+  await bot.api.sendMessage(ctx.chat.id, combinedText);
 });
 
 bot.start();

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Parse Mode plugin for grammY
 
-This plugin provides transformer that injects `entities` or `caption_entities` if `text` or `caption` are FormattedString. It also provides a middleware that installs this transformer on the `ctx.api` object.
+This plugin provides transformer that injects `entities` or `caption_entities`
+if `text` or `caption` are FormattedString. It also provides a middleware that
+installs this transformer on the `ctx.api` object.
 
 ## Usage (Using format)
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,29 @@
 # Parse Mode plugin for grammY
 
-This plugin provides a transformer for setting default `parse_mode`, and a middleware for hydrating `Context` with familiar `reply` variant methods - i.e. `replyWithHTML`, `replyWithMarkdown`, etc.
+This plugin provides transformer that injects `entities` or `caption_entities` if `text` or `caption` are FormattedString. It also provides a middleware that installs this transformer on the `ctx.api` object.
 
 ## Usage (Using format)
 
 ```ts
-import { Bot, Composer, Context } from 'grammy';
+import { Bot, Context } from 'grammy';
 import { bold, fmt, hydrateReply, italic } from '@grammyjs/parse-mode';
 import type { ParseModeFlavor } from '@grammyjs/parse-mode';
 
 const bot = new Bot<ParseModeFlavor<Context>>('');
 
-// Install format reply variant to ctx
-bot.use(hydrateReply);
+// Install automatic entities inject from FormattedString transformer
+bot.use(hydrateReply());
 
 bot.command('demo', async ctx => {
-  await ctx.replyFmt(fmt`${bold('bold!')}
-${bold(italic('bitalic!'))}
-${bold(fmt`bold ${link('blink', 'example.com')} bold`)}`);
+  const boldText = fmt`This is a ${bold('bolded')} string`;
+  await ctx.reply(boldText);
 
-  // fmt can also be called like a regular function
-  await ctx.replyFmt(fmt(['', ' and ', ' and ', ''], fmt`${bold('bold')}`, fmt`${bold(italic('bitalic'))}`, fmt`${italic('italic')}`));
-});
+  const underlineText = fmt`This is an ${underline('underlined')}`;
+  await ctx.reply(underlineText);
 
-bot.start();
-```
-
-## Usage (Using default parse mode and utility reply methods)
-
-```ts
-import { Bot, Composer, Context } from 'grammy';
-import { hydrateReply, parseMode } from '@grammyjs/parse-mode';
-
-import type { ParseModeFlavor } from '@grammyjs/parse-mode';
-
-const bot = new Bot<ParseModeFlavor<Context>>('');
-
-// Install familiar reply variants to ctx
-bot.use(hydrateReply);
-
-// Sets default parse_mode for ctx.reply
-bot.api.config.use(parseMode('MarkdownV2'));
-
-bot.command('demo', async ctx => {
-  await ctx.reply('*This* is _the_ default `formatting`');
-  await ctx.replyWithHTML('<b>This</b> is <i>withHTML</i> <code>formatting</code>');
-  await ctx.replyWithMarkdown('*This* is _withMarkdown_ `formatting`');
-  await ctx.replyWithMarkdownV1('*This* is _withMarkdownV1_ `formatting`');
-  await ctx.replyWithMarkdownV2('*This* is _withMarkdownV2_ `formatting`');
+  // fmt can also be use to concat FormattedStrings
+  cosnt combinedText = fmt`${boldText}\n${underlineText}`
+  await ctx.reply(combinedText);
 });
 
 bot.start();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build": "deno2node tsconfig.json"
   },
   "devDependencies": {
-    "@grammyjs/types": "^3.1.2",
     "@tsconfig/node16": "^1.0.2",
     "@types/node": "^20.4.7",
     "deno2node": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "build": "deno2node tsconfig.json"
   },
   "devDependencies": {
-    "@grammyjs/types": "^3.0.3",
+    "@grammyjs/types": "^3.1.2",
     "@tsconfig/node16": "^1.0.2",
-    "@types/node": "^16.6.1",
-    "deno2node": "^1.8.1",
-    "grammy": "^1.15.3"
+    "@types/node": "^20.4.7",
+    "deno2node": "^1.9.0",
+    "grammy": "^1.17.2"
   },
   "files": [
     "dist/"

--- a/src/README.md
+++ b/src/README.md
@@ -1,31 +1,32 @@
 # Parse Mode plugin for grammY
 
 This plugin provides transformer that injects `entities` or `caption_entities`
-if `text` or `caption` are FormattedString. It also provides a middleware that
-installs this transformer on the `ctx.api` object.
+if `text` or `caption` are FormattedString.
 
 ## Usage (Using format)
 
 ```ts
-import { Bot, Context } from 'grammy';
-import { bold, fmt, hydrateReply, italic } from '@grammyjs/parse-mode';
-import type { ParseModeFlavor } from '@grammyjs/parse-mode';
+import { Api, Bot, Context } from "grammy";
+import { bold, fmt, hydrateFmt, underline } from "@grammyjs/parse-mode";
+import type { ParseModeApiFlavor, ParseModeFlavor } from "@grammyjs/parse-mode";
 
-const bot = new Bot<ParseModeFlavor<Context>>('');
+type MyApi = ParseModeApiFlavor<Api>;
+type MyContext = ParseModeFlavor<Context & { api: MyApi }>;
+const bot = new Bot<MyContext, MyApi>("");
 
 // Install automatic entities inject from FormattedString transformer
-bot.use(hydrateReply());
+bot.api.config.use(hydrateFmt());
 
-bot.command('demo', async ctx => {
-  const boldText = fmt`This is a ${bold('bolded')} string`;
+bot.command("demo", async (ctx) => {
+  const boldText = fmt`This is a ${bold("bolded")} string`;
   await ctx.reply(boldText);
 
-  const underlineText = fmt`This is an ${underline('underlined')}`;
-  await ctx.reply(underlineText);
+  const underlineText = fmt`This is an ${underline("underlined")}`;
+  await ctx.api.sendMessage(ctx.chat.id, underlineText);
 
   // fmt can also be use to concat FormattedStrings
-  cosnt combinedText = fmt`${boldText}\n${underlineText}`
-  await ctx.reply(combinedText);
+  const combinedText = fmt`${boldText}\n${underlineText}`;
+  await bot.api.sendMessage(ctx.chat.id, combinedText);
 });
 
 bot.start();

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,8 @@
 # Parse Mode plugin for grammY
 
-This plugin provides transformer that injects `entities` or `caption_entities` if `text` or `caption` are FormattedString. It also provides a middleware that installs this transformer on the `ctx.api` object.
+This plugin provides transformer that injects `entities` or `caption_entities`
+if `text` or `caption` are FormattedString. It also provides a middleware that
+installs this transformer on the `ctx.api` object.
 
 ## Usage (Using format)
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,53 +1,29 @@
 # Parse Mode plugin for grammY
 
-This plugin provides a transformer for setting default `parse_mode`, and a middleware for hydrating `Context` with familiar `reply` variant methods - i.e. `replyWithHTML`, `replyWithMarkdown`, etc.
+This plugin provides transformer that injects `entities` or `caption_entities` if `text` or `caption` are FormattedString. It also provides a middleware that installs this transformer on the `ctx.api` object.
 
 ## Usage (Using format)
 
 ```ts
-import { Bot, Composer, Context } from 'grammy';
+import { Bot, Context } from 'grammy';
 import { bold, fmt, hydrateReply, italic } from '@grammyjs/parse-mode';
 import type { ParseModeFlavor } from '@grammyjs/parse-mode';
 
 const bot = new Bot<ParseModeFlavor<Context>>('');
 
-// Install format reply variant to ctx
-bot.use(hydrateReply);
+// Install automatic entities inject from FormattedString transformer
+bot.use(hydrateReply());
 
 bot.command('demo', async ctx => {
-  await ctx.replyFmt(fmt`${bold('bold!')}
-${bold(italic('bitalic!'))}
-${bold(fmt`bold ${link('blink', 'example.com')} bold`)}`);
+  const boldText = fmt`This is a ${bold('bolded')} string`;
+  await ctx.reply(boldText);
 
-  // fmt can also be called like a regular function
-  await ctx.replyFmt(fmt(['', ' and ', ' and ', ''], fmt`${bold('bold')}`, fmt`${bold(italic('bitalic'))}`, fmt`${italic('italic')}`));
-});
+  const underlineText = fmt`This is an ${underline('underlined')}`;
+  await ctx.reply(underlineText);
 
-bot.start();
-```
-
-## Usage (Using default parse mode and utility reply methods)
-
-```ts
-import { Bot, Composer, Context } from 'grammy';
-import { hydrateReply, parseMode } from '@grammyjs/parse-mode';
-
-import type { ParseModeFlavor } from '@grammyjs/parse-mode';
-
-const bot = new Bot<ParseModeFlavor<Context>>('');
-
-// Install familiar reply variants to ctx
-bot.use(hydrateReply);
-
-// Sets default parse_mode for ctx.reply
-bot.api.config.use(parseMode('MarkdownV2'));
-
-bot.command('demo', async ctx => {
-  await ctx.reply('*This* is _the_ default `formatting`');
-  await ctx.replyWithHTML('<b>This</b> is <i>withHTML</i> <code>formatting</code>');
-  await ctx.replyWithMarkdown('*This* is _withMarkdown_ `formatting`');
-  await ctx.replyWithMarkdownV1('*This* is _withMarkdownV1_ `formatting`');
-  await ctx.replyWithMarkdownV2('*This* is _withMarkdownV2_ `formatting`');
+  // fmt can also be use to concat FormattedStrings
+  cosnt combinedText = fmt`${boldText}\n${underlineText}`
+  await ctx.reply(combinedText);
 });
 
 bot.start();

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -3,7 +3,4 @@ export type {
   NextFunction,
   Transformer,
 } from "https://lib.deno.dev/x/grammy@^1.0/mod.ts";
-export type {
-  MessageEntity,
-  ParseMode,
-} from "https://esm.sh/@grammyjs/types@2";
+export type { MessageEntity } from "https://lib.deno.dev/x/grammy@^1.0/types.ts";

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,4 +1,5 @@
 export type {
+  Api,
   Context,
   NextFunction,
   Transformer,

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -4,4 +4,7 @@ export type {
   NextFunction,
   Transformer,
 } from "https://lib.deno.dev/x/grammy@^1.0/mod.ts";
-export type { MessageEntity } from "https://lib.deno.dev/x/grammy@^1.0/types.ts";
+export type {
+  InputTextMessageContent,
+  MessageEntity,
+} from "https://lib.deno.dev/x/grammy@^1.0/types.ts";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,2 +1,2 @@
 export type { Api, Context, NextFunction, Transformer } from "grammy";
-export type { MessageEntity } from "grammy/types";
+export type { InputTextMessageContent, MessageEntity } from "grammy/types";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,2 +1,2 @@
-export type { Context, NextFunction, Transformer } from "grammy";
+export type { Api, Context, NextFunction, Transformer } from "grammy";
 export type { MessageEntity } from "grammy/types";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,2 +1,2 @@
 export type { Context, NextFunction, Transformer } from "grammy";
-export type { MessageEntity, ParseMode } from "@grammyjs/types";
+export type { MessageEntity } from "grammy/types";

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,7 +1,7 @@
 import type { MessageEntity } from "./deps.deno.ts";
 
 /**
- * Objects that implement this interface implement a `.toString()` 
+ * Objects that implement this interface implement a `.toString()`
  * method that returns a `string` value representing the object.
  */
 export interface Stringable {
@@ -26,11 +26,11 @@ class FormattedString implements Stringable {
   entities: MessageEntity[];
 
   /**
-   * Creates a new `FormattedString`. Useful for constructing a 
+   * Creates a new `FormattedString`. Useful for constructing a
    * `FormattedString` from user's formatted message
    * @param text Plain text value
    * @param entities Format entities
-   * 
+   *
    * ```ts
    * // Constructing a new `FormattedString` from user's message
    * const userMsg = new FormattedString(ctx.message.text, ctx.entities());
@@ -147,34 +147,45 @@ const customEmoji = (placeholder: Stringable, emoji: number) => {
  * @param chatId The chat ID to link to.
  * @param messageId The message ID to link to.
  */
-const linkMessage = (stringLike: Stringable, chatId: number, messageId: number) => {
+const linkMessage = (
+  stringLike: Stringable,
+  chatId: number,
+  messageId: number,
+) => {
   if (chatId > 0) {
-    console.warn("linkMessage can only be used for supergroups and channel messages. Refusing to transform into link.");
+    console.warn(
+      "linkMessage can only be used for supergroups and channel messages. Refusing to transform into link.",
+    );
     return stringLike;
   } else if (chatId < -1002147483647 || chatId > -1000000000000) {
-    console.warn("linkMessage is not able to link messages whose chatIds are greater than -1000000000000 or less than -1002147483647 at this moment. Refusing to transform into link.");
+    console.warn(
+      "linkMessage is not able to link messages whose chatIds are greater than -1000000000000 or less than -1002147483647 at this moment. Refusing to transform into link.",
+    );
     return stringLike;
   } else {
-    return link(stringLike, `https://t.me/c/${(chatId + 1000000000000) * -1}/${messageId}`);
+    return link(
+      stringLike,
+      `https://t.me/c/${(chatId + 1000000000000) * -1}/${messageId}`,
+    );
   }
 };
 
 // ===  Format tagged template function
 
 /**
- * This is the format tagged template function. It accepts a template literal 
- * containing any mix of `Stringable` and `string` values, and constructs a 
+ * This is the format tagged template function. It accepts a template literal
+ * containing any mix of `Stringable` and `string` values, and constructs a
  * `FormattedString` that represents the combination of all the given values.
- * The constructed `FormattedString` also implements Stringable, and can be used 
+ * The constructed `FormattedString` also implements Stringable, and can be used
  * in further `fmt` tagged templates.
  * @param rawStringParts An array of `string` parts found in the tagged template
  * @param stringLikes An array of `Stringable`s found in the tagged template
- * 
+ *
  * ```ts
  * // Using return values of fmt in fmt
  * const left = fmt`${bold('>>>')} >>>`;
  * const right = fmt`<<< ${bold('<<<')}`;
- * 
+ *
  * const final = fmt`${left} ${ctx.msg.text} ${right}`;
  * await ctx.replyFmt(final);
  * ```

--- a/src/hydrate.ts
+++ b/src/hydrate.ts
@@ -1,26 +1,25 @@
-import type {
-  Context,
-  NextFunction,
-} from "./deps.deno.ts";
+import type { Context, NextFunction } from "./deps.deno.ts";
 
 import { FormattedString } from "./format.ts";
-import { parseMode } from './transformer.ts';
+import { parseMode } from "./transformer.ts";
 
-type Head<T extends Array<unknown>> = T extends [head: infer E1, ...tail: infer E2]
-  ? E1
+type Head<T extends Array<unknown>> = T extends
+  [head: infer E1, ...tail: infer E2] ? E1
   : never;
 
-type Tail<T extends Array<unknown>> = T extends [head: infer E1, ...tail: infer E2]
-  ? E2
+type Tail<T extends Array<unknown>> = T extends
+  [head: infer E1, ...tail: infer E2] ? E2
   : [];
 
 /**
- * Context flavor for `Context` that will be hydrated with 
+ * Context flavor for `Context` that will be hydrated with
  * an additional set of reply methods from `hydrateReply`
  */
 type ParseModeFlavor<C extends Context> = C & {
   editMessageCaption: (
-    other?: Head<Parameters<C["editMessageCaption"]>> & { caption?: FormattedString },
+    other?: Head<Parameters<C["editMessageCaption"]>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Parameters<C["editMessageText"]>>
   ) => ReturnType<C["editMessageCaption"]>;
   editMessageMedia: (
@@ -37,32 +36,44 @@ type ParseModeFlavor<C extends Context> = C & {
   ) => ReturnType<C["reply"]>;
   replyWithAnimation: (
     animation: Head<Parameters<C["replyWithAnimation"]>>,
-    other?: Head<Tail<Parameters<C["replyWithAnimation"]>>> & { caption?: FormattedString },
+    other?: Head<Tail<Parameters<C["replyWithAnimation"]>>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Tail<Parameters<C["replyWithAnimation"]>>>
   ) => ReturnType<C["replyWithAnimation"]>;
   replyWithAudio: (
     audio: Head<Parameters<C["replyWithAudio"]>>,
-    other?: Head<Tail<Parameters<C["replyWithAudio"]>>> & { caption?: FormattedString },
+    other?: Head<Tail<Parameters<C["replyWithAudio"]>>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Tail<Parameters<C["replyWithAudio"]>>>
   ) => ReturnType<C["replyWithAudio"]>;
   replyWithDocument: (
     document: Head<Parameters<C["replyWithDocument"]>>,
-    other?: Head<Tail<Parameters<C["replyWithDocument"]>>> & { caption?: FormattedString },
+    other?: Head<Tail<Parameters<C["replyWithDocument"]>>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Tail<Parameters<C["replyWithDocument"]>>>
   ) => ReturnType<C["replyWithDocument"]>;
   replyWithPhoto: (
     photo: Head<Parameters<C["replyWithPhoto"]>>,
-    other?: Head<Tail<Parameters<C["replyWithPhoto"]>>> & { caption?: FormattedString },
+    other?: Head<Tail<Parameters<C["replyWithPhoto"]>>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Tail<Parameters<C["replyWithPhoto"]>>>
   ) => ReturnType<C["replyWithPhoto"]>;
   replyWithVideo: (
     photo: Head<Parameters<C["replyWithVideo"]>>,
-    other?: Head<Tail<Parameters<C["replyWithVideo"]>>> & { caption?: FormattedString },
+    other?: Head<Tail<Parameters<C["replyWithVideo"]>>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Tail<Parameters<C["replyWithVideo"]>>>
   ) => ReturnType<C["replyWithVideo"]>;
   replyWithVoice: (
     photo: Head<Parameters<C["replyWithVoice"]>>,
-    other?: Head<Tail<Parameters<C["replyWithVoice"]>>> & { caption?: FormattedString },
+    other?: Head<Tail<Parameters<C["replyWithVoice"]>>> & {
+      caption?: FormattedString;
+    },
     ...args: Tail<Tail<Parameters<C["replyWithVoice"]>>>
   ) => ReturnType<C["replyWithVoice"]>;
 };
@@ -72,7 +83,8 @@ type ParseModeFlavor<C extends Context> = C & {
  * @param ctx The context to hydrate
  * @param next The next middleware function
  */
-const middleware = () => async <C extends Context>(
+const middleware = () =>
+async <C extends Context>(
   ctx: ParseModeFlavor<C>,
   next: NextFunction,
 ) => {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,7 +1,11 @@
 import type { Transformer } from "./deps.deno.ts";
 
-import { FormattedString } from './format.ts';
-import { isCaptionEntitiesPayload, isMediaEntitiesPayload, isTextEntitiesPayload } from "./utils.ts";
+import { FormattedString } from "./format.ts";
+import {
+  isCaptionEntitiesPayload,
+  isMediaEntitiesPayload,
+  isTextEntitiesPayload,
+} from "./utils.ts";
 
 /**
  * Creates a new transformer that extracts entities from FormattedString text element.
@@ -14,22 +18,36 @@ const buildTransformer = () => {
       return prev(method, payload, signal);
     }
 
-    if (isCaptionEntitiesPayload(method, payload) && payload.caption instanceof FormattedString) {
+    if (
+      isCaptionEntitiesPayload(method, payload) &&
+      payload.caption instanceof FormattedString
+    ) {
       const caption = payload.caption;
       const entities = payload.caption_entities;
       payload.caption = caption.toString();
-      payload.caption_entities = [...(entities ? entities : []), ...caption.entities]
+      payload.caption_entities = [
+        ...(entities ? entities : []),
+        ...caption.entities,
+      ];
     } else if (isMediaEntitiesPayload(method, payload)) {
-      const iterableMedia = payload.media instanceof Array ? payload.media : [payload.media];
+      const iterableMedia = payload.media instanceof Array
+        ? payload.media
+        : [payload.media];
       for (const media of iterableMedia) {
         if (media.caption instanceof FormattedString) {
           const caption = media.caption;
           const entities = media.caption_entities;
           media.caption = caption.toString();
-          media.caption_entities = [...(entities ? entities : []), ...caption.entities];
+          media.caption_entities = [
+            ...(entities ? entities : []),
+            ...caption.entities,
+          ];
         }
       }
-    } else if (isTextEntitiesPayload(method, payload) && payload.text instanceof FormattedString) {
+    } else if (
+      isTextEntitiesPayload(method, payload) &&
+      payload.text instanceof FormattedString
+    ) {
       const text = payload.text;
       const entities = payload.entities;
       payload.text = text.toString();

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -3,7 +3,10 @@ import type { Transformer } from "./deps.deno.ts";
 import { FormattedString } from "./format.ts";
 import {
   isCaptionEntitiesPayload,
+  isCaptionEntitiesResult,
+  isExplanationEntitiesPayload,
   isMediaEntitiesPayload,
+  isMessageTextEntitiesContent,
   isTextEntitiesPayload,
 } from "./utils.ts";
 
@@ -29,6 +32,17 @@ const buildTransformer = () => {
         ...(entities ? entities : []),
         ...caption.entities,
       ];
+    } else if (
+      isExplanationEntitiesPayload(method, payload) &&
+      payload.explanation instanceof FormattedString
+    ) {
+      const explanation = payload.explanation;
+      const entities = payload.explanation_entities;
+      payload.explanation = explanation.toString();
+      payload.explanation_entities = [
+        ...(entities ? entities : []),
+        ...explanation.entities,
+      ];
     } else if (isMediaEntitiesPayload(method, payload)) {
       const iterableMedia = payload.media instanceof Array
         ? payload.media
@@ -52,10 +66,41 @@ const buildTransformer = () => {
       const entities = payload.entities;
       payload.text = text.toString();
       payload.entities = [...(entities ? entities : []), ...text.entities];
+    } else if ("results" in payload && payload.results instanceof Array) {
+      for (const result of payload.results) {
+        if (
+          isCaptionEntitiesResult(result) &&
+          result.caption instanceof FormattedString
+        ) {
+          const caption = result.caption;
+          const entities = result.caption_entities;
+          result.caption = caption.toString();
+          result.caption_entities = [
+            ...(entities ? entities : []),
+            ...caption.entities,
+          ];
+        }
+
+        if ("input_message_content" in result && result.input_message_content) {
+          const content = result.input_message_content;
+          if (
+            isMessageTextEntitiesContent(content) &&
+            content.message_text instanceof FormattedString
+          ) {
+            const text = content.message_text;
+            const entities = content.entities;
+            content.message_text = text.toString();
+            content.entities = [
+              ...(entities ? entities : []),
+              ...text.entities,
+            ];
+          }
+        }
+      }
     }
     return prev(method, payload, signal);
   };
   return transformer;
 };
 
-export { buildTransformer as parseMode };
+export { buildTransformer };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,58 +1,67 @@
 import type { MessageEntity } from "./deps.deno.ts";
 
-import { FormattedString } from './format.ts';
+import { FormattedString } from "./format.ts";
 
 interface CaptionEntitiesPayload {
-    caption: FormattedString | string | undefined;
-    caption_entities: MessageEntity[];
+  caption: FormattedString | string | undefined;
+  caption_entities: MessageEntity[];
 }
 
 interface MediaEntitiesPayload {
-    media: CaptionEntitiesPayload | CaptionEntitiesPayload[];
+  media: CaptionEntitiesPayload | CaptionEntitiesPayload[];
 }
 
 interface TextEntitiesPayload {
-    text: FormattedString | string | undefined;
-    entities: MessageEntity[];
+  text: FormattedString | string | undefined;
+  entities: MessageEntity[];
 }
 
 const captionEntitiesMethod = new Set([
-    'editMessageCaption',
-    'sendAnimation',
-    'sendAudio',
-    'sendDocument',
-    'sendPhoto',
-    'sendVideo',
-    'sendVoice',
+  "editMessageCaption",
+  "sendAnimation",
+  "sendAudio",
+  "sendDocument",
+  "sendPhoto",
+  "sendVideo",
+  "sendVoice",
 ]);
 
 const mediaEntitiesMethod = new Set([
-    'editMessageMedia',
-    'sendMediaGroup',
+  "editMessageMedia",
+  "sendMediaGroup",
 ]);
 
 const textEntitiesMethod = new Set([
-    'editMessageText',
-    'sendMessage',
+  "editMessageText",
+  "sendMessage",
 ]);
 
 // deno-lint-ignore no-explicit-any
-function isCaptionEntitiesPayload(method: any, _payload: any): _payload is CaptionEntitiesPayload {
-    return captionEntitiesMethod.has(method);
+function isCaptionEntitiesPayload(
+  method: any,
+  _payload: any,
+): _payload is CaptionEntitiesPayload {
+  return captionEntitiesMethod.has(method);
 }
 
 // deno-lint-ignore no-explicit-any
-function isMediaEntitiesPayload(method: any, _payload: any): _payload is MediaEntitiesPayload {
-    return mediaEntitiesMethod.has(method);
+function isMediaEntitiesPayload(
+  method: any,
+  _payload: any,
+): _payload is MediaEntitiesPayload {
+  return mediaEntitiesMethod.has(method);
 }
 
 // deno-lint-ignore no-explicit-any
-function isTextEntitiesPayload(method: any, _payload: any): _payload is TextEntitiesPayload {
-    return textEntitiesMethod.has(method);
+function isTextEntitiesPayload(
+  method: any,
+  _payload: any,
+): _payload is TextEntitiesPayload {
+  return textEntitiesMethod.has(method);
 }
 
 export {
-    isCaptionEntitiesPayload,
-    isMediaEntitiesPayload,
-    isTextEntitiesPayload,
+  isCaptionEntitiesPayload,
+  isMediaEntitiesPayload,
+  isTextEntitiesPayload,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,26 +36,23 @@ const textEntitiesMethod = new Set([
   "sendMessage",
 ]);
 
-// deno-lint-ignore no-explicit-any
 function isCaptionEntitiesPayload(
-  method: any,
-  _payload: any,
+  method: string,
+  _payload: unknown,
 ): _payload is CaptionEntitiesPayload {
   return captionEntitiesMethod.has(method);
 }
 
-// deno-lint-ignore no-explicit-any
 function isMediaEntitiesPayload(
-  method: any,
-  _payload: any,
+  method: string,
+  _payload: unknown,
 ): _payload is MediaEntitiesPayload {
   return mediaEntitiesMethod.has(method);
 }
 
-// deno-lint-ignore no-explicit-any
 function isTextEntitiesPayload(
-  method: any,
-  _payload: any,
+  method: string,
+  _payload: unknown,
 ): _payload is TextEntitiesPayload {
   return textEntitiesMethod.has(method);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,58 @@
+import type { MessageEntity } from "./deps.deno.ts";
+
+import { FormattedString } from './format.ts';
+
+interface CaptionEntitiesPayload {
+    caption: FormattedString | string | undefined;
+    caption_entities: MessageEntity[];
+}
+
+interface MediaEntitiesPayload {
+    media: CaptionEntitiesPayload | CaptionEntitiesPayload[];
+}
+
+interface TextEntitiesPayload {
+    text: FormattedString | string | undefined;
+    entities: MessageEntity[];
+}
+
+const captionEntitiesMethod = new Set([
+    'editMessageCaption',
+    'sendAnimation',
+    'sendAudio',
+    'sendDocument',
+    'sendPhoto',
+    'sendVideo',
+    'sendVoice',
+]);
+
+const mediaEntitiesMethod = new Set([
+    'editMessageMedia',
+    'sendMediaGroup',
+]);
+
+const textEntitiesMethod = new Set([
+    'editMessageText',
+    'sendMessage',
+]);
+
+// deno-lint-ignore no-explicit-any
+function isCaptionEntitiesPayload(method: any, _payload: any): _payload is CaptionEntitiesPayload {
+    return captionEntitiesMethod.has(method);
+}
+
+// deno-lint-ignore no-explicit-any
+function isMediaEntitiesPayload(method: any, _payload: any): _payload is MediaEntitiesPayload {
+    return mediaEntitiesMethod.has(method);
+}
+
+// deno-lint-ignore no-explicit-any
+function isTextEntitiesPayload(method: any, _payload: any): _payload is TextEntitiesPayload {
+    return textEntitiesMethod.has(method);
+}
+
+export {
+    isCaptionEntitiesPayload,
+    isMediaEntitiesPayload,
+    isTextEntitiesPayload,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,21 +2,32 @@ import type { MessageEntity } from "./deps.deno.ts";
 
 import { FormattedString } from "./format.ts";
 
-interface CaptionEntitiesPayload {
-  caption: FormattedString | string | undefined;
-  caption_entities: MessageEntity[];
+interface CaptionEntities {
+  caption?: FormattedString | string;
+  caption_entities?: MessageEntity[];
 }
 
-interface MediaEntitiesPayload {
-  media: CaptionEntitiesPayload | CaptionEntitiesPayload[];
+interface ExplanationEntities {
+  explanation?: FormattedString | string;
+  explanation_entities?: MessageEntity[];
 }
 
-interface TextEntitiesPayload {
-  text: FormattedString | string | undefined;
-  entities: MessageEntity[];
+interface MediaEntities {
+  media: CaptionEntities | CaptionEntities[];
+}
+
+interface MessageTextEntities {
+  message_text: FormattedString | string;
+  entities?: MessageEntity[];
+}
+
+interface TextEntities {
+  text: FormattedString | string;
+  entities?: MessageEntity[];
 }
 
 const captionEntitiesMethod = new Set([
+  "copyMessage",
   "editMessageCaption",
   "sendAnimation",
   "sendAudio",
@@ -24,6 +35,10 @@ const captionEntitiesMethod = new Set([
   "sendPhoto",
   "sendVideo",
   "sendVoice",
+]);
+
+const explanationEntitiesMethod = new Set([
+  "sendPoll",
 ]);
 
 const mediaEntitiesMethod = new Set([
@@ -39,26 +54,48 @@ const textEntitiesMethod = new Set([
 function isCaptionEntitiesPayload(
   method: string,
   _payload: unknown,
-): _payload is CaptionEntitiesPayload {
+): _payload is CaptionEntities {
   return captionEntitiesMethod.has(method);
+}
+
+function isExplanationEntitiesPayload(
+  method: string,
+  _payload: unknown,
+): _payload is ExplanationEntities {
+  return explanationEntitiesMethod.has(method);
 }
 
 function isMediaEntitiesPayload(
   method: string,
   _payload: unknown,
-): _payload is MediaEntitiesPayload {
+): _payload is MediaEntities {
   return mediaEntitiesMethod.has(method);
 }
 
 function isTextEntitiesPayload(
   method: string,
   _payload: unknown,
-): _payload is TextEntitiesPayload {
+): _payload is TextEntities {
   return textEntitiesMethod.has(method);
+}
+
+function isCaptionEntitiesResult(
+  result: {},
+): result is CaptionEntities {
+  return result instanceof Object && "caption" in result;
+}
+
+function isMessageTextEntitiesContent(
+  content: {},
+): content is MessageTextEntities {
+  return content instanceof Object && "message_text" in content;
 }
 
 export {
   isCaptionEntitiesPayload,
+  isCaptionEntitiesResult,
+  isExplanationEntitiesPayload,
   isMediaEntitiesPayload,
+  isMessageTextEntitiesContent,
   isTextEntitiesPayload,
 };


### PR DESCRIPTION
And:
- ~~Standardise exported middleware type signature (i.e. () => mw instead of mw)~~
- Export transformer instead of middleware
- Provide Api Flavor with updated README
- remove parse_mode completely to signal strong disuse recommendation

TODO:
- answerInlineQuery