### PR TITLE
feat: handle arrays in `fmt`

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -213,7 +213,7 @@ const fmt = (
           })),
         );
       }
-      text += stringLike.toString();
+      if (stringLike != null) text += stringLike.toString();
     }
   }
   return new FormattedString(text, entities);


### PR DESCRIPTION
Allow `fmt` to be called like a regular function with a single array argument. This was already kinda supported but:

1. The string parts array could only contain strings. Now it can contain stringables as well like the rest arguments.
2. You had to use both first arg array and rest args and their items would be zipped. After this change you can simply pass one array argument with mix of strings and stringables.
3. Nested arrays would be toStringed and formatting inside them would be lost. I changed it so nested arrays are handled properly.