### PR TITLE
feat: support fmt in media captions

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -61,3 +61,49 @@ bot.command("demo", async (ctx) => {
 
 bot.start();
 ```
+
+## Using fmt in media captions
+
+In addition to the existing `replyFmt` method, you can now use the following new methods to apply fmt formatting to media captions:
+
+- `replyFmtWithPhoto(photo, options)`: Send a photo with a formatted caption 
+- `replyFmtWithMediaGroup(media)`: Send a media group with formatted captions
+- `editFmtMessageMedia(media, options)`: Edit media and formatted caption in a message
+- `editFmtMessageText(text, options)`: Edit formatted text in a message
+
+All of these functions are used in the same way as the official functions that do not have Fmt.
+
+```ts
+bot.use(hydrateReplyFmt);
+
+await ctx.replyFmtWithPhoto("photo_url", {
+  caption: fmt`This is a ${bold("formatted")} caption`,
+});
+
+await ctx.replyFmtWithMediaGroup([
+  {
+    type: "photo",
+    media: "photo1_url", 
+    caption: fmt`First photo with ${italic("italic")} text`
+  },
+  {
+    type: "photo",
+    media: "photo2_url",
+    caption: fmt`Second photo with ${code("code")} text` 
+  }
+]);
+
+await ctx.editFmtMessageMedia(
+  {
+    type: "photo",
+    media: "new_photo_url",  
+    caption: fmt`Updated ${bold("caption")}`,  
+  },
+  { reply_markup: { inline_keyboard: [...] } }
+);
+
+await ctx.editFmtMessageText(
+  fmt`Edited ${underline("message")} text`,
+  { reply_markup: { inline_keyboard: [...] } }  
+);
+```

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -4,11 +4,24 @@ import type {
   Transformer,
 } from "https://lib.deno.dev/x/grammy@^1.20/mod.ts";
 
+import type {
+  InputMediaPhoto,
+  InputMediaVideo,
+  InputMediaAnimation,
+  InputMediaAudio,
+  InputMediaDocument,
+} from "https://lib.deno.dev/x/grammy@^1.20/types.ts";
+
 export type {
   Context,
   NextFunction,
   Transformer,
-};
+  InputMediaPhoto,
+  InputMediaVideo,
+  InputMediaAnimation,
+  InputMediaAudio,
+  InputMediaDocument,
+}
 
 export type MessageEntity = NonNullable<NonNullable<Parameters<Context["reply"]>[1]>["entities"]>[number];
 export type ParseMode = NonNullable<NonNullable<Parameters<Context["reply"]>[1]>["parse_mode"]>;

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,9 +1,24 @@
 import type { Context, NextFunction, Transformer } from "grammy";
+import type {
+    InputMediaPhoto,
+    InputMediaVideo,
+    InputMediaAnimation,
+    InputMediaAudio,
+    InputMediaDocument,
+  } from "grammy/types";
 
 export type {
     Context,
     NextFunction,
     Transformer,
+  };
+
+export type {
+    InputMediaPhoto,
+    InputMediaVideo,
+    InputMediaAnimation,
+    InputMediaAudio,
+    InputMediaDocument,
   };
   
   export type MessageEntity = NonNullable<NonNullable<Parameters<Context["reply"]>[1]>["entities"]>[number];


### PR DESCRIPTION
According to Issue https://github.com/grammyjs/parse-mode/issues/22 , this PR adds support for using fmt in media captions, including:

- `replyFmtWithPhoto`: send a photo with a formatted caption
- `replyFmtWithMediaGroup`: send a media group with formatted captions
- `editFmtMessageMedia`: edit media and formatted caption in a message
- `editFmtMessageText`: edit formatted text in a message

Changes made in this PR:

1. `deps.deno.ts` and `deps.node.ts`:
   - Import `InputMedia*` types from the correct paths.
   - Export `InputMedia*` types.

2. `hydrate.ts`:
   - Add new methods to `ParseModeFlavor` type: `replyFmtWithPhoto`, `replyFmtWithMediaGroup`, `editFmtMessageMedia`, `editFmtMessageText`.
   - Implement the new methods in `hydrateReplyFmt` middleware.
   - Update `replyFmtWithMediaGroup` to accept any `InputMedia*` type.

3. `README.md`:
   - Add documentation for the new methods in the "Using fmt in media captions" section.
   - Provide usage examples for the new methods.
   - Explain that `editFmtMessageMedia` allows changing the media type when editing a message.

Test: `deno run --allow-net --allow-read --allow-env test.ts`

```ts
import { Bot, Context } from "https://deno.land/x/grammy@v1.12.0/mod.ts";
import {
    hydrateReply,
    hydrateReplyFmt,
    ParseModeFlavor,
    bold,
    code,
    fmt,
    italic,
} from "./mod.ts";

const BOT_TOKEN = "";

const bot = new Bot<ParseModeFlavor<Context>>(BOT_TOKEN);

bot.use(hydrateReply);
bot.use(hydrateReplyFmt);

bot.command("start", async (ctx) => {
    await ctx.reply("Bot started. Send /test to test the plugin.");
});

bot.command("test", async (ctx) => {
    await ctx.replyFmt(fmt`This is a ${bold("formatted")} message.`);

    await ctx.replyFmtWithPhoto("http://placehold.co/600x400/EEE/31343C.jpg", {
        caption: fmt`This is a ${bold("formatted")} caption`,
    });

    await ctx.replyFmtWithMediaGroup([
        {
            type: "photo",
            media: "http://placehold.co/600x400/CCC/31343C.jpg",
            caption: fmt`First photo with ${italic("italic")} text`
        },
        {
            type: "video",
            media: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4",
            caption: fmt`A ${code("video")} with formatted caption`
        }
    ]);
});

bot.catch((err) => {
    console.error(err);
});

bot.start();
```