### PR TITLE
Implement  FormattedString method

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -43,6 +43,42 @@ class FormattedString implements Stringable {
   }
 
   /**
+   * Replaces matches of a pattern with a replacement string
+   *
+   * @param searchValue The pattern to search for
+   * @param replaceValue The string to replace the pattern with
+   * @returns A new `FormattedString` with replacements
+   */
+  replace(searchValue: string | RegExp, replaceValue: string): FormattedString {
+    const newText = this.text.replace(searchValue, replaceValue);
+
+    const newEntities = this.entities.map(entity => {
+      const newEntity = { ...entity };
+
+      if (typeof searchValue === 'string') {
+        const index = this.text.indexOf(searchValue);
+
+        if (index !== -1 && index < newEntity.offset + newEntity.length) {
+          newEntity.offset = newEntity.offset + replaceValue.length - searchValue.length;
+        }
+      } else {
+        const match = this.text.match(searchValue);
+
+        if (match) {
+          const index = match.index!;
+          if (index !== -1 && index < newEntity.offset + newEntity.length) {
+            newEntity.offset = newEntity.offset + replaceValue.length - match[0].length;
+          }
+        }
+      }
+
+      return newEntity;
+    });
+
+    return new FormattedString(newText, newEntities);
+  }
+
+  /**
    * Returns the string representation of this object
    */
   toString() {


### PR DESCRIPTION
This PR adds a simplified implementation of the basic [replace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) method from the JavaScript String class that preserves the original formatting after replacing text.

Problem:

```typescript
bot.hears('test', async (ctx) => {
    const msg = fmt`I like the ${code('grammY')} framework`;
    const newText = msg.toString().replace('like', 'very love');

    const newMsg = new FormattedString(newText, msg.entities);

    await ctx.replyFmt(newMsg);
});
```

![Screenshot_20240601_230429_Telegram](https://github.com/grammyjs/parse-mode/assets/40361422/b8f6b369-068f-411f-9fef-0733d3beb53f)

Solution after changes:

```typescript
bot.hears('test', async (ctx) => {
    const msg = fmt`I like the ${code('grammY')} framework`;

    const newMsg = msg.replace('like', 'very love');

    await ctx.replyFmt(newMsg);
});
```

![Screenshot_20240601_230652_Telegram](https://github.com/grammyjs/parse-mode/assets/40361422/4dd11bb7-6d4a-4678-a907-19ade3761823)
