### PR TITLE
Allow strings as custom emoji ids

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -143,7 +143,7 @@ const mentionUser = (stringLike: Stringable, userId: number) => {
  * @param placeholder A placeholder emoji
  * @param emoji The custom emoji identifier
  */
-const customEmoji = (placeholder: Stringable, emoji: number | string) => {
+const customEmoji = (placeholder: Stringable, emoji: string) => {
   return link(placeholder, `tg://emoji?id=${emoji}`);
 };
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -143,7 +143,7 @@ const mentionUser = (stringLike: Stringable, userId: number) => {
  * @param placeholder A placeholder emoji
  * @param emoji The custom emoji identifier
  */
-const customEmoji = (placeholder: Stringable, emoji: number) => {
+const customEmoji = (placeholder: Stringable, emoji: number | string) => {
   return link(placeholder, `tg://emoji?id=${emoji}`);
 };
 


### PR DESCRIPTION
Grammy's message entities represent custom emoji ids as strings. Also, numerical ids can be too big to accurately represent with javascript's numbers.