### PR TITLE
feat: add date_time MessageEntity

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "devDependencies": {
     "@types/node": "^16.6.1",
     "deno2node": "^1.8.1",
-    "grammy": "^1.36.1"
+    "grammy": "^1.41.0"
   },
   "peerDependencies": {
-    "grammy": "^1.36.1"
+    "grammy": "^1.41.0"
   },
   "files": [
     "dist/"

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,4 +1,4 @@
 export type {
   MessageEntity,
   User,
-} from "https://lib.deno.dev/x/grammy@^1.36/types.ts";
+} from "https://lib.deno.dev/x/grammy@^1.41/types.ts";

--- a/src/entity-tag.ts
+++ b/src/entity-tag.ts
@@ -109,6 +109,11 @@ export function emoji(customEmojiId: string) {
   return buildFormatter("custom_emoji")({ custom_emoji_id: customEmojiId });
 }
 
+/**
+ * `date_time` entity tag. Incompatible with `code` and `pre`.
+ * @param unixTime The Unix timestamp required by Telegram.
+ * @param dateTimeFormat The optional Telegram `date_time` formatting string.
+ */
 export function time(
   unixTime: number,
   dateTimeFormat?: MessageEntity.DateTimeMessageEntity["date_time_format"],

--- a/src/entity-tag.ts
+++ b/src/entity-tag.ts
@@ -5,15 +5,13 @@ import type { MessageEntity } from "./deps.deno.ts";
  */
 export type EntityTag = Omit<MessageEntity, "offset" | "length">;
 
-function buildFormatter<T extends Array<unknown> = never>(
-  type: MessageEntity["type"],
-  ...formatArgKeys: T
-): (...formatArgs: T) => EntityTag {
-  return (...formatArgs) => {
-    const formatArgObj = Object.fromEntries(
-      formatArgKeys.map((formatArgKey, i) => [formatArgKey, formatArgs[i]]),
-    );
-    return { type, ...formatArgObj };
+function buildFormatter<T extends MessageEntity["type"]>(
+  type: T,
+): (
+  formatOpts?: Omit<MessageEntity & { type: T }, "type" | "offset" | "length">,
+) => EntityTag {
+  return (formatOpts) => {
+    return { type, ...formatOpts };
   };
 }
 
@@ -72,14 +70,14 @@ export function underline() {
  * @param url The URL to link to.
  */
 export function a(url: string) {
-  return buildFormatter<[url: string]>("text_link", "url")(url);
+  return buildFormatter("text_link")({ url });
 }
 /**
  * `link` entity tag. Incompatible with `code` and `pre`.
  * @param url The URL to link to.
  */
 export function link(url: string) {
-  return buildFormatter<[url: string]>("text_link", "url")(url);
+  return buildFormatter("text_link")({ url });
 }
 
 /**
@@ -93,9 +91,7 @@ export function code() {
  * @param language The language of the code block.
  */
 export function pre(language?: string) {
-  return buildFormatter<[language: string | undefined]>("pre", "language")(
-    language,
-  );
+  return buildFormatter("pre")({ language });
 }
 
 /**
@@ -110,10 +106,17 @@ export function spoiler() {
  * @param customEmojiId The custom emoji ID.
  */
 export function emoji(customEmojiId: string) {
-  return buildFormatter<[customEmojiId: string]>(
-    "custom_emoji",
-    "custom_emoji_id",
-  )(customEmojiId);
+  return buildFormatter("custom_emoji")({ custom_emoji_id: customEmojiId });
+}
+
+export function time(
+  unixTime: number,
+  dateTimeFormat?: MessageEntity.DateTimeMessageEntity["date_time_format"],
+) {
+  return buildFormatter("date_time")({
+    unix_time: unixTime,
+    date_time_format: dateTimeFormat ?? "",
+  });
 }
 
 /**

--- a/src/format.ts
+++ b/src/format.ts
@@ -16,6 +16,7 @@ import {
   s,
   spoiler,
   strikethrough,
+  time,
   u,
   underline,
 } from "./entity-tag.ts";
@@ -415,6 +416,21 @@ export class FormattedString
   }
 
   /**
+   * Creates a date_time formatted string
+   * @param text The text content to format as a date_time entity
+   * @param unixTime The Unix timestamp required by Telegram
+   * @param dateTimeFormat The optional Telegram date_time formatting string
+   * @returns A new FormattedString with date_time formatting applied
+   */
+  static time(
+    text: Stringable,
+    unixTime: number,
+    dateTimeFormat?: MessageEntity.DateTimeMessageEntity["date_time_format"],
+  ) {
+    return fmt`${time(unixTime, dateTimeFormat)}${text}${time}`;
+  }
+
+  /**
    * Creates a message link formatted string
    * @param text The text content to display for the link
    * @param chatId The chat ID containing the message
@@ -719,6 +735,21 @@ export class FormattedString
    */
   emoji(text: Stringable, customEmojiId: string) {
     return fmt`${this}${FormattedString.emoji(text, customEmojiId)}`;
+  }
+
+  /**
+   * Combines this FormattedString with a date_time formatted string
+   * @param text The text content to format as a date_time entity and append
+   * @param unixTime The Unix timestamp required by Telegram
+   * @param dateTimeFormat The optional Telegram date_time formatting string
+   * @returns A new FormattedString combining this instance with date_time formatting
+   */
+  time(
+    text: Stringable,
+    unixTime: number,
+    dateTimeFormat?: MessageEntity.DateTimeMessageEntity["date_time_format"],
+  ) {
+    return fmt`${this}${FormattedString.time(text, unixTime, dateTimeFormat)}`;
   }
 
   /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -63,6 +63,11 @@ export function isEntitySimilar(
     return entity1.custom_emoji_id === entity2.custom_emoji_id;
   }
 
+  if (entity1.type === "date_time" && entity2.type === "date_time") {
+    return entity1.unix_time === entity2.unix_time &&
+      (entity1.date_time_format ?? "") === (entity2.date_time_format ?? "");
+  }
+
   if (entity1.type === "text_mention" && entity2.type === "text_mention") {
     return isUserSimilar(entity1.user, entity2.user);
   }
@@ -171,6 +176,10 @@ export function consolidateEntities(
       key += `|${sortedEntity.language || ""}`;
     } else if (sortedEntity.type === "custom_emoji") {
       key += `|${sortedEntity.custom_emoji_id}`;
+    } else if (sortedEntity.type === "date_time") {
+      key += `|${sortedEntity.unix_time}|${
+        sortedEntity.date_time_format ?? ""
+      }`;
     } else if (sortedEntity.type === "text_mention") {
       // Use user.id as key, nothing we can do about different User object with same id (e.g. username changes over time)
       key += `|${sortedEntity.user.id}`;
@@ -254,6 +263,13 @@ function compareEntities(a: MessageEntity, b: MessageEntity): number {
 
   if (a.type === "custom_emoji" && b.type === "custom_emoji") {
     return a.custom_emoji_id.localeCompare(b.custom_emoji_id);
+  }
+
+  if (a.type === "date_time" && b.type === "date_time") {
+    if (a.unix_time !== b.unix_time) {
+      return a.unix_time - b.unix_time;
+    }
+    return (a.date_time_format ?? "").localeCompare(b.date_time_format ?? "");
   }
 
   if (a.type === "text_mention" && b.type === "text_mention") {

--- a/test/format.time.test.ts
+++ b/test/format.time.test.ts
@@ -1,0 +1,69 @@
+import { assertEquals, assertInstanceOf, describe, it } from "./deps.test.ts";
+import type { MessageEntity } from "../src/deps.deno.ts";
+import { FormattedString } from "../src/format.ts";
+
+describe("FormattedString - time formatting methods", () => {
+  it("Static time method", () => {
+    const text = "March 13, 2026, 14:30";
+    const unixTime = 1773412200;
+    const dateTimeFormat = "DT";
+
+    const timeFormatted = FormattedString.time(text, unixTime, dateTimeFormat);
+
+    assertInstanceOf(timeFormatted, FormattedString);
+    assertEquals(timeFormatted.rawText, text);
+    const entity = timeFormatted.rawEntities[0] as
+      | MessageEntity.DateTimeMessageEntity
+      | undefined;
+
+    assertEquals(timeFormatted.rawEntities.length, 1);
+    assertEquals(entity?.type, "date_time");
+    assertEquals(entity?.offset, 0);
+    assertEquals(entity?.length, text.length);
+    assertEquals(entity?.unix_time, unixTime);
+    assertEquals(entity?.date_time_format, dateTimeFormat);
+  });
+
+  it("Instance time method", () => {
+    const initialText = "Reminder: ";
+    const text = "March 13, 2026, 14:30";
+    const unixTime = 1773412200;
+    const dateTimeFormat = "DT";
+    const initialFormatted = new FormattedString(initialText);
+
+    const timeResult = initialFormatted.time(text, unixTime, dateTimeFormat);
+
+    assertInstanceOf(timeResult, FormattedString);
+    assertEquals(timeResult.rawText, `${initialText}${text}`);
+    const entity = timeResult.rawEntities[0] as
+      | MessageEntity.DateTimeMessageEntity
+      | undefined;
+
+    assertEquals(timeResult.rawEntities.length, 1);
+    assertEquals(entity?.type, "date_time");
+    assertEquals(entity?.offset, initialText.length);
+    assertEquals(entity?.length, text.length);
+    assertEquals(entity?.unix_time, unixTime);
+    assertEquals(entity?.date_time_format, dateTimeFormat);
+  });
+
+  it("Static time method without format", () => {
+    const text = "Today";
+    const unixTime = 1773412200;
+
+    const timeFormatted = FormattedString.time(text, unixTime);
+
+    assertInstanceOf(timeFormatted, FormattedString);
+    assertEquals(timeFormatted.rawText, text);
+    const entity = timeFormatted.rawEntities[0] as
+      | MessageEntity.DateTimeMessageEntity
+      | undefined;
+
+    assertEquals(timeFormatted.rawEntities.length, 1);
+    assertEquals(entity?.type, "date_time");
+    assertEquals(entity?.offset, 0);
+    assertEquals(entity?.length, text.length);
+    assertEquals(entity?.unix_time, unixTime);
+    assertEquals(entity?.date_time_format, "");
+  });
+});

--- a/test/util.date_time.test.ts
+++ b/test/util.date_time.test.ts
@@ -1,0 +1,118 @@
+import { assertEquals, describe, it } from "./deps.test.ts";
+import {
+  canConsolidateEntities,
+  consolidateEntities,
+  isEntitiesEqual,
+  isEntityEqual,
+  isEntitySimilar,
+} from "../src/util.ts";
+import type { MessageEntity } from "../src/deps.deno.ts";
+
+describe("util - date_time entities", () => {
+  it("isEntitySimilar considers unix_time and date_time_format", () => {
+    const entity: MessageEntity = {
+      type: "date_time",
+      offset: 0,
+      length: 5,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    };
+    const same: MessageEntity = {
+      type: "date_time",
+      offset: 10,
+      length: 5,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    };
+    const differentUnixTime: MessageEntity = {
+      type: "date_time",
+      offset: 10,
+      length: 5,
+      unix_time: 1773412201,
+      date_time_format: "DT",
+    };
+    const differentFormat: MessageEntity = {
+      type: "date_time",
+      offset: 10,
+      length: 5,
+      unix_time: 1773412200,
+      date_time_format: "wdT",
+    };
+
+    assertEquals(isEntitySimilar(entity, same), true);
+    assertEquals(isEntitySimilar(entity, differentUnixTime), false);
+    assertEquals(isEntitySimilar(entity, differentFormat), false);
+  });
+
+  it("isEntityEqual and isEntitiesEqual distinguish date_time metadata", () => {
+    const entity: MessageEntity = {
+      type: "date_time",
+      offset: 0,
+      length: 5,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    };
+    const same: MessageEntity = {
+      type: "date_time",
+      offset: 0,
+      length: 5,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    };
+    const different: MessageEntity = {
+      type: "date_time",
+      offset: 0,
+      length: 5,
+      unix_time: 1773412200,
+      date_time_format: "wdT",
+    };
+
+    assertEquals(isEntityEqual(entity, same), true);
+    assertEquals(isEntityEqual(entity, different), false);
+    assertEquals(isEntitiesEqual([entity], [same]), true);
+    assertEquals(isEntitiesEqual([entity], [different]), false);
+  });
+
+  it("consolidates only matching date_time entities", () => {
+    const left: MessageEntity = {
+      type: "date_time",
+      offset: 0,
+      length: 4,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    };
+    const adjacentSame: MessageEntity = {
+      type: "date_time",
+      offset: 4,
+      length: 3,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    };
+    const adjacentDifferent: MessageEntity = {
+      type: "date_time",
+      offset: 7,
+      length: 2,
+      unix_time: 1773412200,
+      date_time_format: "wdT",
+    };
+
+    assertEquals(canConsolidateEntities(left, adjacentSame), true);
+    assertEquals(canConsolidateEntities(left, adjacentDifferent), false);
+
+    const consolidated = consolidateEntities([
+      adjacentDifferent,
+      adjacentSame,
+      left,
+    ]);
+
+    assertEquals(consolidated.length, 2);
+    assertEquals(consolidated[0], {
+      type: "date_time",
+      offset: 0,
+      length: 7,
+      unix_time: 1773412200,
+      date_time_format: "DT",
+    });
+    assertEquals(consolidated[1], adjacentDifferent);
+  });
+});


### PR DESCRIPTION
This pull request adds support for Telegram's `date_time` message entity, allowing formatted strings to include date and time metadata. The changes upgrade the `grammy` dependency, update types, add new utility and formatting methods for `date_time`, and introduce comprehensive tests to ensure correct functionality and consolidation behavior.

**Date_time entity support:**

* Added a new `time` function in `src/entity-tag.ts` to create `date_time` entity tags, and updated the `buildFormatter` function to support this entity type.
* Introduced static and instance `time` methods in the `FormattedString` class to allow easy creation and combination of date_time formatted strings. [[1]](diffhunk://#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36bR418-R432) [[2]](diffhunk://#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36bR740-R754)
* Added `date_time` handling to utility functions for entity comparison, consolidation, and sorting in `src/util.ts`. [[1]](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R66-R70) [[2]](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R179-R182) [[3]](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R268-R274)

**Dependency and type updates:**

* Upgraded the `grammy` dependency in `package.json` and updated the Deno types import to match the new version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L27-R30) [[2]](diffhunk://#diff-1f6f06ffdff13bc5394df222422f6364a7abb96d569dbc073300d9e26bcafa04L4-R4)

**Testing:**

* Added new test files for `date_time` entity formatting and utility functions, covering creation, comparison, and consolidation. [[1]](diffhunk://#diff-e202404e60a7fbcb2dfdae7a4168ba100c3ad812a4bbcf1b7e0e0d945ba5c39dR1-R69) [[2]](diffhunk://#diff-919a861c7cd76e0cad0c8c84f288144d1ba45ba3ed733093c0bbf6ee9b1ff01cR1-R118)