### PR TITLE
Fix stream parser to handle contiguous opening brackets correctly

### DIFF
--- a/src/stream-html-to-format.ts
+++ b/src/stream-html-to-format.ts
@@ -467,6 +467,17 @@ export class HTMLStreamParser {
   }
 
   private addCharInCloseTagNameMode(char: string): void {
+    // If we encounter another `<`, the current partial close tag was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     const isWhitespaceChar = isWhitespace(char);
@@ -550,6 +561,17 @@ export class HTMLStreamParser {
   }
 
   private addCharInOpenTagNameMode(char: string): void {
+    // If we encounter another `<`, the current partial open tag was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     const isWhitespaceChar = isWhitespace(char);

--- a/src/stream-html-to-format.ts
+++ b/src/stream-html-to-format.ts
@@ -705,6 +705,15 @@ export class HTMLStreamParser {
   }
 
   private addCharInDecisionOpenTagNameOrCloseTagNameMode(char: string): void {
+    // If we encounter another `<`, the previous `<` was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     if (char === "/") {

--- a/test/stream-html-to-format.test.ts
+++ b/test/stream-html-to-format.test.ts
@@ -145,6 +145,72 @@ describe("HTMLStreamParser", () => {
     assertEquals(formatted.rawEntities[0]?.length, 4);
   });
 
+  it("flushes partial open tag and restarts on <: <b<b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bbold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial open tag across stream boundary: <b then <b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b");
+    parser.add("<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bbold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial open tag for different tags: <i<b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<i<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<ibold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial close tag and restarts on <: <b>bold</</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>bold</</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "bold</");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 0);
+    assertEquals(formatted.rawEntities[0]?.length, 6);
+  });
+
+  it("flushes partial close tag mid-name: <b>bold</b<b>more</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>bold</b<b>more</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "bold</bmore");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 7);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
   it("toFormattedString is idempotent for unchanged parser state", () => {
     const parser = new HTMLStreamParser();
     parser.add("<i>ok</i>");

--- a/test/stream-html-to-format.test.ts
+++ b/test/stream-html-to-format.test.ts
@@ -131,6 +131,20 @@ describe("HTMLStreamParser", () => {
     assertEquals(formatted.rawEntities[0]?.length, "spoiler & text".length);
   });
 
+  it("evaluates contiguous opening brackets as plain text", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<<b");
+    parser.add(">bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 1);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
   it("toFormattedString is idempotent for unchanged parser state", () => {
     const parser = new HTMLStreamParser();
     parser.add("<i>ok</i>");


### PR DESCRIPTION
This pull request improves the robustness of the `HTMLStreamParser` by handling cases where multiple consecutive `<` characters appear in the input, ensuring that malformed or ambiguous tag openings/closings are treated as plain text. It also adds comprehensive tests to cover these edge cases.

### Parser robustness improvements

* Updated the parser logic in `src/stream-html-to-format.ts` to detect when a `<` character appears while already parsing a potential tag (open, close, or ambiguous), treating the previous partial tag as plain text and restarting tag detection with the new `<`. This prevents malformed tags from being incorrectly parsed as valid HTML entities. [[1]](diffhunk://#diff-81f56b482ae878a148b5d81fdedefd9dea5555f60d41212e7b82e0d79ba2e386R470-R480) [[2]](diffhunk://#diff-81f56b482ae878a148b5d81fdedefd9dea5555f60d41212e7b82e0d79ba2e386R564-R574) [[3]](diffhunk://#diff-81f56b482ae878a148b5d81fdedefd9dea5555f60d41212e7b82e0d79ba2e386R730-R738)

### Test coverage enhancements

* Added multiple tests in `test/stream-html-to-format.test.ts` to verify correct handling of contiguous `<` characters, partial open/close tags, and edge cases where tag boundaries occur across input chunks. These tests ensure the parser correctly flushes partial tags as plain text and maintains accurate entity extraction.